### PR TITLE
Remove Apache 2.0 license header

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,3 @@
-/*
- * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
- * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2022 Datadog, Inc.
- */
-
 const core = require('@actions/core');
 const exec = require('@actions/exec');
 const io = require('@actions/io');


### PR DESCRIPTION
### What and why?

Remove Apache 2.0 headers, since the project has MIT license.

### How?

Apache 2.0 license header is removed from the JS file.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
