### PR TITLE
updated parameters naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ GitHub Action to run your Swift or Objective-C tests automatically instrumented 
 ## Usage
 
 1. Set [Datadog API key](https://app.datadoghq.com/organization-settings/api-keys) inside Settings > Secrets as `DD_API_KEY`.
-2. Set [Datadog Application key](https://app.datadoghq.com/organization-settings/application-keys) inside Settings > Secrets as `DD_APPLICATION_KEY`.
+2. Set [Datadog Application key](https://app.datadoghq.com/organization-settings/application-keys) inside Settings > Secrets as `DD_APP_KEY`.
 3. Add a step to your GitHub Actions workflow YAML that uses this action:
 
    ```yaml
@@ -22,7 +22,7 @@ GitHub Action to run your Swift or Objective-C tests automatically instrumented 
       uses: Datadog/swift-test-action@v1
       with:
           api_key: ${{ secrets.DD_API_KEY }}
-          application_key: ${{ secrets.DD_APPLICATION_KEY }}
+          app_key: ${{ secrets.DD_APP_KEY }}
    ```
 
 ## Configuration

--- a/index.js
+++ b/index.js
@@ -23,11 +23,11 @@ let envVars = Object.assign({}, process.env);
 async function run() {
   try {
     const apiKey =  core.getInput("api_key");
-    const applicationKey =  core.getInput("application_key");
+    const applicationKey =  core.getInput("app_key");
 
 
     if (!apiKey || !applicationKey) {
-      console.error(`Error: Both api_key and application_key parameters are needed for the action`);
+      console.error(`Error: Both api_key and app_key parameters are needed for the action`);
       return
     }
 


### PR DESCRIPTION
### What and why?

We want to have parameters naming consistent between all our github actions.

### How?

Changed `application_key` to `app_key`.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration)
- [ ] Make sure each commit and the PR mention the Issue number or JIRA reference
